### PR TITLE
Improve vlurp dx

### DIFF
--- a/.changeset/friendly-bears-dance.md
+++ b/.changeset/friendly-bears-dance.md
@@ -1,0 +1,10 @@
+---
+"vlurp": minor
+---
+
+Improve vlurp user experience based on v1.0.0 feedback:
+
+- **Terminology**: Replace all "clone" references with "vlurp" to better reflect that we download tarballs
+- **Enhanced default filters**: Now includes `*.md` files (excluding common repo files), `/agents` and `/commands` directories. Refactored to use `glob` for cleaner, more reliable pattern matching
+- **Re-vlurping protection**: Warns when overwriting existing directories, shows file count, can bypass with `--force` flag
+- **Tree display**: Automatically shows directory structure after vlurping with total file count using ASCII tree. Fixed to show hidden directories like `.claude`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing to vlurp! This document provides gui
 ## Development
 
 ```sh
-# clone the repository
+# Clone the repository
 git clone git@github.com:indexzero/vlurp.git
 
 # Install dependencies

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ npx vlurp <user>/<repo>
 ## Usage
 
 ```sh
-# Vlurp a repository using user/repo format
+# vlurp a repository using user/repo format
 vlurp cool-repo/has-agents
 # → Creates ./cool-repo/has-agents
 
-# Vlurp to a specific directory
+# vlurp to a specific directory
 vlurp cool-repo/has-agents -d ~/projects
 # → Creates ~/projects/cool-repo/has-agents
 
-# Vlurp using a GitHub URL
+# vlurp using a GitHub URL
 vlurp https://github.com/whoever/cool-configs
 # → Creates ./whoever/cool-configs
 
-# Vlurp a GitHub Gist
+# vlurp a GitHub Gist
 vlurp https://gist.github.com/user/abc123def456
 # → Creates ./user/abc123def456
 
@@ -40,10 +40,10 @@ vlurp --help
 # Filter files (default: .claude/** and CLAUDE.md)
 vlurp cool-repo/has-agents --filter "*.ts" --filter "*.tsx"
 
-# Vlurp only specific directories
+# vlurp only specific directories
 vlurp whoever/cool-configs --filter "lib/**" --filter "doc/**"
 
-# Vlurp only markdown files
+# vlurp only markdown files
 vlurp user/repo --filter "*.md"
 ```
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "vlurp": "./bin/vlurp"
   },
   "scripts": {
-    "test": "node --test",
+    "test": "node --test test/*.test.js",
     "lint": "xo",
     "lint:fix": "xo --fix",
     "changeset": "changeset"
@@ -16,7 +16,7 @@
   "keywords": [
     "cli",
     "github",
-    "clone",
+    "vlurp",
     "download",
     "fetch",
     "repository",
@@ -29,6 +29,8 @@
   },
   "packageManager": "pnpm@10.14.0",
   "dependencies": {
+    "archy": "^1.0.0",
+    "glob": "^11.0.3",
     "hosted-git-info": "^9.0.0",
     "ink": "^6.1.0",
     "ink-spinner": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      archy:
+        specifier: ^1.0.0
+        version: 1.0.0
+      glob:
+        specifier: ^11.0.3
+        version: 11.0.3
       hosted-git-info:
         specifier: ^9.0.0
         version: 9.0.0
@@ -471,6 +477,9 @@ packages:
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
+
+  archy@1.0.0:
+    resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1070,6 +1079,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -1126,6 +1139,11 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@11.0.3:
+    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+    engines: {node: 20 || >=22}
+    hasBin: true
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1702,6 +1720,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
@@ -1739,6 +1760,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2781,6 +2806,8 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
+  archy@1.0.0: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -3529,6 +3556,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -3600,6 +3632,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@11.0.3:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.1
+      minimatch: 10.0.3
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
 
   globals@14.0.0: {}
 
@@ -4144,6 +4185,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.10
@@ -4172,6 +4215,11 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.1.0
+      minipass: 7.1.2
 
   path-type@4.0.0: {}
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,21 +10,24 @@ const j = jack({
   .description('A fun CLI tool to quickly fetch GitHub repositories and gists')
   .opt({
     d: {
-      description: 'Root directory for cloning',
+      description: 'Root directory for vlurping',
       short: 'd'
     }
   })
   .optList({
     filter: {
-      description: 'Glob patterns to filter files (defaults to .claude/** and CLAUDE.md)',
-      short: 'f',
-      default: ['.claude/**', 'CLAUDE.md']
+      description: 'Glob patterns to filter files (see defaults in help)',
+      default: ['.claude/**', 'CLAUDE.md', '*.md', '!README.md', '!CONTRIBUTING.md', '!LICENSE.md', '!CHANGELOG.md', '!CODE_OF_CONDUCT.md', 'agents/**', 'commands/**']
     }
   })
   .flag({
     help: {
       description: 'Show this help message',
       short: 'h'
+    },
+    force: {
+      description: 'Force overwrite existing directories without prompting',
+      short: 'f'
     }
   });
 
@@ -40,9 +43,10 @@ Usage:
   vlurp <url> -d <root>                 Fetch to <root>/<user>/<repo>
 
 Examples:
-  vlurp facebook/react                   Fetch with default filters (.claude/**, CLAUDE.md)
+  vlurp facebook/react                   Fetch with default filters
   vlurp nodejs/node --filter "*.js"      Fetch only JavaScript files
-  vlurp user/repo -f "src/**" -f "*.md"  Fetch src folder and markdown files
+  vlurp user/repo --filter "src/**"      Fetch src folder
+  vlurp user/repo --force                Force overwrite existing directory
 
 Options:
 ${j.usage()}`);
@@ -57,5 +61,8 @@ if (positionals.length === 0) {
 const source = positionals[0];
 const rootDir = values.d;
 const filters = values.filter;
+const {force} = values;
 
-render(React.createElement(FetchCommand, { source, rootDir, filters }));
+render(React.createElement(FetchCommand, {
+  source, rootDir, filters, force
+}));

--- a/src/tree.js
+++ b/src/tree.js
@@ -1,0 +1,39 @@
+import { readdir } from 'node:fs/promises';
+import { join, basename } from 'node:path';
+import archy from 'archy';
+
+async function buildTree(dir, name = null) {
+  const label = name || basename(dir);
+
+  try {
+    // Use withFileTypes to avoid stat calls
+    const entries = await readdir(dir, { withFileTypes: true });
+
+    const children = await Promise.all(entries
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(async entry => {
+        if (entry.isDirectory()) {
+          return buildTree(join(dir, entry.name), entry.name);
+        }
+
+        return entry.name;
+      }));
+
+    return {
+      label,
+      nodes: children
+    };
+  } catch {
+    // If readdir fails, it's likely a file, not a directory
+    return label;
+  }
+}
+
+export async function buildTreeString(dir) {
+  try {
+    const tree = await buildTree(dir);
+    return archy(tree);
+  } catch {
+    return null;
+  }
+}

--- a/test/vlurp.test.js
+++ b/test/vlurp.test.js
@@ -1,9 +1,13 @@
 import process from 'node:process';
 import { describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { minimatch } from 'minimatch';
 import { Validator, Parser } from '../src/index.js';
 import { resolveTargetPath } from '../src/commands/fetch.js';
+import { buildTreeString } from '../src/tree.js';
 
 describe('Validator', () => {
   const validator = new Validator();
@@ -95,9 +99,7 @@ describe('resolveTargetPath', () => {
 });
 
 describe('Filter functionality', () => {
-  it('should match files with glob patterns', async () => {
-    const { minimatch } = await import('minimatch');
-
+  it('should match files with glob patterns', () => {
     // Test basic patterns
     assert.ok(minimatch('README.md', '*.md'));
     assert.ok(minimatch('src/index.js', 'src/**'));
@@ -109,8 +111,7 @@ describe('Filter functionality', () => {
     assert.ok(!minimatch('lib/index.js', 'src/**'));
   });
 
-  it('should filter with multiple patterns', async () => {
-    const { minimatch } = await import('minimatch');
+  it('should filter with multiple patterns', () => {
     const filters = ['*.md', 'src/**', '.claude/**'];
 
     const testFiles = [
@@ -133,9 +134,7 @@ describe('Filter functionality', () => {
     ]);
   });
 
-  it('should handle .claude/** pattern for eyaltoledano/claude-task-master repo structure', async () => {
-    const { minimatch } = await import('minimatch');
-
+  it('should handle .claude/** pattern for eyaltoledano/claude-task-master repo structure', () => {
     // Test paths from the claude-task-master repository
     const claudePaths = [
       '.claude/TM_COMMANDS_GUIDE.md',
@@ -167,5 +166,75 @@ describe('Filter functionality', () => {
         `Expected ${path} to NOT match .claude/**`
       );
     });
+  });
+
+  it('should have correctly formatted default filters for glob', () => {
+    // Default filters as defined in cli.js
+    const defaultFilters = ['.claude/**', 'CLAUDE.md', '*.md', '!README.md', '!CONTRIBUTING.md', '!LICENSE.md', '!CHANGELOG.md', '!CODE_OF_CONDUCT.md', 'agents/**', 'commands/**'];
+
+    // Simply verify our default filters are properly formatted for glob
+    // We trust glob to handle the actual pattern matching correctly
+
+    const ignorePatterns = defaultFilters.filter(p => p.startsWith('!'));
+    const includePatterns = defaultFilters.filter(p => !p.startsWith('!'));
+
+    // Verify we have both include and exclude patterns
+    assert.ok(includePatterns.length > 0, 'Should have include patterns');
+    assert.ok(ignorePatterns.length > 0, 'Should have ignore patterns');
+
+    // Verify ignore patterns are properly formatted with !
+    ignorePatterns.forEach(pattern => {
+      assert.ok(pattern.startsWith('!'), `Ignore pattern ${pattern} should start with !`);
+    });
+
+    // Verify include patterns don't start with !
+    includePatterns.forEach(pattern => {
+      assert.ok(!pattern.startsWith('!'), `Include pattern ${pattern} should not start with !`);
+    });
+
+    // Verify specific patterns we expect
+    assert.ok(includePatterns.includes('*.md'), 'Should include markdown files');
+    assert.ok(includePatterns.includes('.claude/**'), 'Should include .claude directory');
+    assert.ok(includePatterns.includes('agents/**'), 'Should include agents directory');
+    assert.ok(includePatterns.includes('commands/**'), 'Should include commands directory');
+
+    // Verify specific exclusions
+    assert.ok(ignorePatterns.includes('!README.md'), 'Should exclude README.md');
+    assert.ok(ignorePatterns.includes('!CONTRIBUTING.md'), 'Should exclude CONTRIBUTING.md');
+  });
+});
+
+describe('Tree display', () => {
+  it('should include hidden directories in tree output', async () => {
+    // Use test/fixtures instead of os.tmpdir for safety
+    const testFixturesDir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+    const testDir = join(testFixturesDir, 'tree-test');
+
+    try {
+      // Ensure fixtures directory exists
+      await mkdir(testFixturesDir, { recursive: true });
+      // Create test directory structure
+      await mkdir(testDir, { recursive: true });
+      await mkdir(join(testDir, '.claude'), { recursive: true });
+      await mkdir(join(testDir, 'visible-dir'), { recursive: true });
+      await writeFile(join(testDir, 'README.md'), 'test');
+      await writeFile(join(testDir, '.hidden-file'), 'test');
+      await writeFile(join(testDir, '.claude', 'config.json'), 'test');
+      await writeFile(join(testDir, 'visible-dir', 'file.js'), 'test');
+
+      // Build tree string
+      const treeOutput = await buildTreeString(testDir);
+
+      // Verify tree output includes hidden directories and files
+      assert.ok(treeOutput, 'Tree output should be generated');
+      assert.ok(treeOutput.includes('.claude'), 'Tree should include .claude directory');
+      assert.ok(treeOutput.includes('.hidden-file'), 'Tree should include hidden files');
+      assert.ok(treeOutput.includes('visible-dir'), 'Tree should include visible directories');
+      assert.ok(treeOutput.includes('README.md'), 'Tree should include regular files');
+      assert.ok(treeOutput.includes('config.json'), 'Tree should include files within hidden directories');
+    } finally {
+      // Clean up test directory only (not the fixtures directory)
+      await rm(testDir, { recursive: true, force: true });
+    }
   });
 });

--- a/xo.config.js
+++ b/xo.config.js
@@ -6,6 +6,7 @@ export default {
     'unicorn/prevent-abbreviations': 'off',
     'import/extensions': 'off',
     '@stylistic/comma-dangle': ['error', 'never'],
+    '@stylistic/indent-binary-ops': ['error', 2],
     '@stylistic/object-curly-spacing': 'off',
     'unicorn/no-process-exit': 'off',
     'unicorn/import-style': 'off',


### PR DESCRIPTION
Improve vlurp dx

- **Terminology**: Replace all "clone" references with "vlurp" to better reflect that we download tarballs
- **Enhanced default filters**: Now includes `*.md` files (excluding common repo files), `/agents` and `/commands` directories. Refactored to use `glob` for cleaner, more reliable pattern matching
- **Re-vlurping protection**: Warns when overwriting existing directories, shows file count, can bypass with `--force` flag
- **Tree display**: Automatically shows directory structure after vlurping with total file count using ASCII tree. Fixed to show hidden directories like `.claude`
- **Use `glob`**: Avoid reinventing the ~wheel~ `glob`