### PR TITLE
build: add repository metadata required for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,14 @@
   ],
   "author": "Charlie Robbins <npm@charlie.dev>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/indexzero/vlurp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/indexzero/vlurp/issues"
+  },
+  "homepage": "https://github.com/indexzero/vlurp#readme",
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
**No `repository` field in `package.json`** — npm provenance generation *and* the Trusted Publisher matcher both require it
