### PR TITLE
ci: install npm >=11.5.1 so pnpm can do OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,13 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      # `changeset publish` runs `pnpm publish`, and pnpm delegates the npm
+      # OIDC trusted-publishing token exchange to the npm CLI — which must be
+      # >= 11.5.1. Node 22 ships npm 10.x, so without this the publish goes out
+      # unauthenticated and the registry returns E404.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Why

Follow-up to #17. That PR got us most of the way: the last Release run **authenticated via OIDC and signed provenance** to the Sigstore transparency log — but the final `PUT https://registry.npmjs.org/vlurp` returned **`E404 Not Found`**, i.e. pnpm published **unauthenticated**.

## Root cause

`changeset publish` shells out to `pnpm publish`, and **pnpm delegates the npm OIDC trusted-publishing token exchange to the npm CLI**, which must be **≥ 11.5.1** ([npm docs](https://docs.npmjs.com/trusted-publishers/); cf. pnpm#9812 → "ensure npm@11 is installed for OIDC publishing").

GitHub's Node 22 runner ships **npm 10.x**, which can't perform the exchange. Provenance still signed because that uses the GitHub OIDC id-token directly via Sigstore — independent of registry auth — which is why we saw a signed attestation *and* a 404.

## Fix

Add one step before publish:

```yaml
- name: Upgrade npm for OIDC trusted publishing
  run: npm install -g npm@latest
```

## Result

Merging this runs the Release workflow again. With `package.json` still at `2.0.0` (npm latest `1.2.0`) and no pending changesets, `pnpm changeset publish` will perform the OIDC exchange via npm >=11.5.1 and publish `vlurp@2.0.0` with provenance, then tag `v2.0.0`.